### PR TITLE
Update default app root folder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,7 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  push
 
 jobs:
   build:

--- a/src/configure.js
+++ b/src/configure.js
@@ -1,9 +1,33 @@
+const os = require('os');
+const path = require('path');
 const readline = require('readline');
 const { writeUserConfig } = require('./user-config');
 
+/**
+ * appRootFolder default value
+ * 
+ * Returns the PWD. If PWD is the same as the module path, returns the
+ * path for a "Notes" folder in the user's home directory.
+ * 
+ * @requires os
+ * @requires path
+ * 
+ * @returns {String}
+ */
+function defaultAppRootFolder() {
+  const pwd = process.env.PWD;
+  const modulePath = path.dirname(__dirname);
+
+  if (modulePath === pwd) {
+    return path.resolve(os.homedir(), 'Notes');
+  }
+
+  return pwd;
+}
+
 const questions = [
   {
-    defaultValue: process.env.PWD,
+    defaultValue: defaultAppRootFolder(),
     key: 'appRootFolder',
     text: 'Application root folder location'
   },


### PR DESCRIPTION
Updates the `appRootFolder.defaultValue` to use new `defaultAppRootFolder()` function. When `$PWD` is the module path (i.e. when configuration is run after a global install or in local development), the path of a `Notes` folder in the user's home directory is suggested instead of `$PWD`