### PR TITLE
Implement user folder watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Watch file changes in the background and automatically update `README.md` files 
 > notepack watch
 ```
 
+### notepack status
+
+Display the status of the watcher.
+
+```sh
+> notepack status
+```
+
 ### notepack stop
 
 Stop watching for file changes.

--- a/bin/notepack
+++ b/bin/notepack
@@ -16,12 +16,24 @@ SCRIPTS_PATH="$DIR/../src"
 # Filepath for active watch process monitoring
 WATCHING_PATH="$HOME/.notepack_watching"
 
+# Filepath for configuration
+CONFIG_PATH="$HOME/.notepack_config"
+
+configure () {
+  node $SCRIPTS_PATH/configure.js
+}
+
+# Alternate to "wait" that allows waiting for processes that are not a child
+# of the current shell. Only works on processes the user has permissions to
+# terminate (which works well enough for our purposes).
+detatched_wait () {
+  while kill -0 $1 2> /dev/null; do sleep 0.1; done;
+}
+
 is_configured () {
-  if [ -f "$HOME/.notepack_config" ]
+  if [ -f $CONFIG_PATH ]
     then return 0
-    else
-      echo -e "Please configure your Notepack first by running \x1b[1;33m\x1b[1mnotepack configure\x1b[0m"
-      return 1
+    else return 1
   fi
 }
 
@@ -29,6 +41,52 @@ is_watching () {
   if [ -f $WATCHING_PATH ]
     then return 0
     else return 1
+  fi
+}
+
+postinstall () {
+  if is_configured
+    then restart_watcher
+    else
+      configure
+  fi
+}
+
+restart_watcher () {
+  if is_watching
+    then
+      echo -e "\x1b[1;33mRestarting watcher...\x1b[0m"
+      pid=$(< $WATCHING_PATH)
+      kill $pid
+      detatched_wait $pid
+      start_watching
+  fi
+}
+
+speak_configuration_status () {
+  if is_configured
+    then return 0
+    else
+      echo -e "Please configure your Notepack first by running \x1b[1;33m\x1b[1mnotepack configure\x1b[0m"
+      return 1
+  fi
+}
+
+speak_todos () {
+  if [ $1 ]
+    then
+      node $SCRIPTS_PATH/todos.js --asignedTo $1
+    else
+      node $SCRIPTS_PATH/todos.js
+  fi
+}
+
+speak_watching_status () {
+  if is_watching
+    then
+      echo -e "\x1b[0;34mWatching notes in the background (pid: $(< $WATCHING_PATH))\x1b[0m"
+    else
+      echo -e "Not watching notes. Run \x1b[1;33m\x1b[1mnotepack watch\x1b[0m to start watching."
   fi
 }
 
@@ -49,20 +107,11 @@ stop_watching () {
   fi
 }
 
-todos () {
-  if [ $1 ]
-    then
-      node $SCRIPTS_PATH/todos.js --asignedTo $1
-    else
-      node $SCRIPTS_PATH/todos.js
-  fi
-}
-
-update() {
+update_todos () {
   node $SCRIPTS_PATH/updateTodos.js
 }
 
-watch() {
+watch () {
   if is_watching
     then
       if ps -p $(< $WATCHING_PATH) > /dev/null
@@ -79,21 +128,27 @@ watch() {
 
 case "$1" in
 "configure")
-  node $SCRIPTS_PATH/configure.js
+  configure
+  ;;
+"postinstall")
+  postinstall
+  ;;
+"status")
+  speak_watching_status
   ;;
 "stop")
-  if is_configured; then stop_watching; fi
+  speak_configuration_status && stop_watching
   ;;
 "todos")
-  if is_configured; then todos $2; fi
+  speak_configuration_status && speak_todos $2
   ;;
 "update")
-  if is_configured; then update; fi
+  speak_configuration_status && update_todos
   ;;
 "watch")
-  if is_configured; then watch; fi
+  speak_configuration_status && watch
   ;;
 *)
-  if is_configured; then todos; fi
+  speak_configuration_status && speak_todos
   ;;
 esac

--- a/bin/notepack
+++ b/bin/notepack
@@ -14,7 +14,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 SCRIPTS_PATH="$DIR/../src"
 
 # Filepath for active watch process monitoring
-WATCHING_PATH="$DIR/../.WATCHING"
+WATCHING_PATH="$HOME/.notepack_watching"
 
 is_configured () {
   if [ -f "$HOME/.notepack_config" ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Local note taking CLI helpers",
   "main": "index.js",
   "scripts": {
-    "postinstall": "node scripts/postinstall.js",
+    "postinstall": "./bin/notepack postinstall",
     "test": "jest"
   },
   "bin": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,9 +1,0 @@
-const os = require('os');
-const path = require('path');
-const { CONFIG_FILE_NAME } = require('../src/constants');
-const fs = require('fs');
-const CONFIG_FILE_PATH = path.resolve(os.homedir(), CONFIG_FILE_NAME);
-
-if (!fs.existsSync(CONFIG_FILE_PATH)) {
-  require('../src/configure');
-}

--- a/src/__tests__/watch.test.js
+++ b/src/__tests__/watch.test.js
@@ -14,6 +14,7 @@ const watchModel = require('../watch');
 const { exitScript } = require('../watch');
 const { BASE_FOLDERS, TEAM_FOLDER } = notepackConfigMock;
 const { watcher, updateTodosForAll, updateTodosForMe } = watchModel;
+const { WATCHING_FILE_NAME } = require('../constants');
 
 jest.mock('fs');
 jest.mock('process');
@@ -100,15 +101,15 @@ describe('exitScript()', () => {
     fs.unlinkSync = jest.fn();
   });
 
-  test('removes .WATCHING file when it exists', () => {
+  test(`removes ${WATCHING_FILE_NAME} file when it exists`, () => {
     fs.existsSync = jest.fn(() => true);
 
     exitScript();
 
-    expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringContaining('.WATCHING'));
+    expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringContaining(WATCHING_FILE_NAME));
   });
 
-  test('does not remove .WATCHING file when it is not found', () => {
+  test(`does not remove ${WATCHING_FILE_NAME} file when it is not found`, () => {
     fs.existsSync = jest.fn(() => false);
 
     exitScript();

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,14 @@ const { argv } = require('yargs');
 const CONFIG_FILE_NAME = '.notepack_config';
 
 /**
+ * File to track watching status
+ * 
+ * @constant
+ * @type {String}
+ */
+const WATCHING_FILE_NAME = '.notepack_watching';
+
+/**
  * Invalid file type patterns
  *
  * @constant
@@ -57,5 +65,6 @@ module.exports = {
   FILE_IGNORE,
   MATCH_PATTERN,
   RUNNING_IN_BACKGROUND,
-  RUNNING_TESTS
+  RUNNING_TESTS,
+  WATCHING_FILE_NAME
 }

--- a/src/watch.js
+++ b/src/watch.js
@@ -1,9 +1,10 @@
 const chokidar = require('chokidar');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const updateTodos = require('./updateTodos');
 const team = require('./team');
-const { RUNNING_TESTS } = require('./constants');
+const { RUNNING_TESTS, WATCHING_FILE_NAME } = require('./constants');
 const { APP_ROOT_FOLDER, BASE_FOLDERS, TEAM_FOLDER } = require('./userConfig').getUserConfig();
 
 // Watch location based on user specified APP_ROOT_FOLDER
@@ -26,7 +27,7 @@ const model = {
  * @requires path
  */
 function exitScript() {
-  const watchingFilePath = path.join(path.dirname(__dirname), '.WATCHING')
+  const watchingFilePath = path.join(os.homedir(), WATCHING_FILE_NAME)
 
   // Gate removal of file for testing
   if (fs.existsSync(watchingFilePath)) {


### PR DESCRIPTION
Moves the watching status file to the user's home folder instead of local to the installed package. This will enable restarting the watcher automatically after an upgrade. Along the way, the bash file has been organized a little better and a new `status` command is also introduced to check the current watching status.