### PR TITLE
Adds PID running check to is_watching

### DIFF
--- a/bin/notepack
+++ b/bin/notepack
@@ -42,7 +42,12 @@ is_configured () {
 
 is_watching () {
   if [ -f $WATCHING_PATH ]
-    then return 0
+    then
+      # Be sure process is actually running
+      if [ -n "$(ps -p $(<$WATCHING_PATH) -o pid=)" ]
+        then return 0
+        else return 1
+      fi
     else return 1
   fi
 }


### PR DESCRIPTION
Adds additional check to `is_watching` method to make `notepack status` report more accurately. The `is_watching` method now checks for presence of the watching file _and_ checks to see if the PID logged there is actually running.