### PR TITLE
Update url encoding

### DIFF
--- a/bin/notepack
+++ b/bin/notepack
@@ -143,6 +143,10 @@ stop_watching () {
   fi
 }
 
+update_recent_files () {
+  node $SCRIPTS_PATH/updateRecentFiles.js
+}
+
 update_todos () {
   node $SCRIPTS_PATH/updateTodos.js
 }
@@ -182,7 +186,7 @@ case "$1" in
   speak_configuration_status && speak_todos $2
   ;;
 "update")
-  speak_configuration_status && update_todos
+  speak_configuration_status && update_todos && update_recent_files
   ;;
 "watch")
   speak_configuration_status && watch

--- a/src/__tests__/updateTodos.test.js
+++ b/src/__tests__/updateTodos.test.js
@@ -36,7 +36,13 @@ describe('getGroupNames()', () => {
 });
 
 describe('groupRelativePath()', () => {
-  const groupFilePath = './Project 1/Note 1.md';
+  const UN_ENCODED_CHARS = {
+    '%2F': '/',
+    '%3A': ':',
+    '%2B': '+',
+    '%2C': ','
+  };
+  const groupFilePath = './Project 1/Note 1 + 2: foo, bar.md';
   const result = groupRelativePath(readmeFilePath, groupFilePath);
 
   test('returns a String', () => {
@@ -47,9 +53,13 @@ describe('groupRelativePath()', () => {
     expect(result).toEqual(expect.stringContaining('%20'));
   });
 
-  test('returns an encoded file path with %2F characters un-encoded', () => {
-    expect(result).toEqual(expect.stringContaining('/'));
-    expect(result).toEqual(expect.not.stringContaining('%2F'));
+  Object.keys(UN_ENCODED_CHARS).forEach((encoded) => {
+    const unencoded = UN_ENCODED_CHARS[encoded];
+
+    test(`returns an encoded file path with ${encoded} characters un-encoded`, () => {
+      expect(result).toEqual(expect.stringContaining(unencoded));
+      expect(result).toEqual(expect.not.stringContaining(encoded));
+    });
   });
 });
 

--- a/src/__tests__/updateTodos.test.js
+++ b/src/__tests__/updateTodos.test.js
@@ -132,9 +132,9 @@ describe('updateTodosForFolders()', () => {
 
   test('calls writeTodos for directories with README.md files', () => {
     updateTodosForFolders(['Notes/Projects']);
-    expect(updateTodos.writeTodos).toHaveBeenCalledWith(expect.stringContaining('Project 1/README.md'), expect.any(Array));    
+    expect(updateTodos.writeTodos).toHaveBeenCalledWith(expect.stringContaining('Project 1/README.md'), expect.any(Array));
   });
-  
+
   test('does not call writeTodos for directories with README.md files', () => {
     updateTodosForFolders(['Notes/Projects']);
     expect(updateTodos.writeTodos).not.toHaveBeenCalledWith(expect.stringContaining('Project 2/README.md'), expect.any(Array));
@@ -150,12 +150,12 @@ describe('updateTodosForPerson()', () => {
     updateTodosForPerson('Jane');
     expect(updateTodos.writeTodos).toHaveBeenCalledWith(expect.stringContaining('Jane'), expect.any(Array));
   });
-  
+
   test('calls writeTodos for the project root README when no team member is passed in', () => {
     updateTodosForPerson();
     expect(updateTodos.writeTodos).toHaveBeenCalledWith(path.join(APP_ROOT_FOLDER, 'README.md'), expect.any(Array));
   });
-  
+
   test('calls writeTodos for the project root README when "me" is passed in', () => {
     updateTodosForPerson('me');
     expect(updateTodos.writeTodos).toHaveBeenCalledWith(path.join(APP_ROOT_FOLDER, 'README.md'), expect.any(Array));
@@ -173,7 +173,7 @@ describe('writeTodos()', () => {
 
     expect(writeTodos('README.md', [])).toBeFalsy();
   });
-  
+
   test('logs an error if file is not writable and not running in the background', () => {
     fs.accessSync = jest.fn(() => {
       throw new Error('error');
@@ -185,7 +185,7 @@ describe('writeTodos()', () => {
     writeTodos('README.md', []);
     expect(console.error).toHaveBeenCalled();
   });
-  
+
   test('writes todos to the end of the file if no TODO_ANCHOR can be found', () => {
     fs.accessSync = jest.fn(() => true);
     fs.readFileSync = jest.fn().mockReturnValue('# Start of File\n\n# End of File');

--- a/src/recentFiles.js
+++ b/src/recentFiles.js
@@ -123,7 +123,7 @@ function updateRecentFiles(limit = RECENT_FILES_COUNT, lastNDays = RECENT_FILES_
         resolve(writeRecentFiles(data));
       })
       .catch(error => reject(error));
-});
+  });
 }
 
 function writeRecentFiles(recentFiles) {

--- a/src/recentFiles.js
+++ b/src/recentFiles.js
@@ -168,8 +168,6 @@ ${recentFiles.map(({filepath, filename}) => `* [${filename}](${relativeRecentFil
   // End of todos chunk to end of file
   chunks.push(src.substring(end).trim());
 
-  console.log(chunks.join('\n\n').trim() + '\n');
-
   fs.writeFileSync(readmeFilePath, chunks.join('\n\n').trim());
 
   return true;

--- a/src/recentFiles.js
+++ b/src/recentFiles.js
@@ -85,7 +85,11 @@ function getRecentFiles(limit = RECENT_FILES_COUNT, lastNDays = RECENT_FILES_DAY
  */
 function relativeRecentFilePath(readmeFilePath, filePath) {
   const relativeFilePath = path.relative(path.dirname(readmeFilePath), filePath);
-  return encodeURIComponent(relativeFilePath).replace(/%2F/g, '/');
+  return encodeURIComponent(relativeFilePath)
+          .replace(/%2F/g, '/')
+          .replace(/%3A/g, ':')
+          .replace(/%2B/g, '+')
+          .replace(/%2C/g, ',');
 }
 
 function logRecentFiles(recentFiles, limit = RECENT_FILES_COUNT, lastNDays = RECENT_FILES_DAY_WINDOW) {

--- a/src/updateRecentFiles.js
+++ b/src/updateRecentFiles.js
@@ -1,0 +1,3 @@
+const { updateRecentFiles } = require('./recentFiles');
+
+updateRecentFiles();

--- a/src/updateTodos.js
+++ b/src/updateTodos.js
@@ -57,7 +57,11 @@ function getGroupNames(todos) {
  */
 function groupRelativePath(readmeFilePath, groupFilePath) {
   const relativeFilePath = path.relative(path.dirname(readmeFilePath), path.join(APP_ROOT_FOLDER, groupFilePath));
-  return encodeURIComponent(relativeFilePath).replace(/%2F/g, '/');
+  return encodeURIComponent(relativeFilePath)
+          .replace(/%2F/g, '/')
+          .replace(/%3A/g, ':')
+          .replace(/%2B/g, '+')
+          .replace(/%2C/g, ',');
 }
 
 /**

--- a/src/updateTodos.js
+++ b/src/updateTodos.js
@@ -23,12 +23,12 @@ module.exports = model;
 
 /**
  * Get todo group names
- * 
+ *
  * Iterates through todos and builds a deduped array of groupName values,
  * sorted by file date in descending order.
- * 
+ *
  * @param {Array} todos Todos to parse
- * 
+ *
  * @return {Array}
  */
 function getGroupNames(todos) {
@@ -44,15 +44,15 @@ function getGroupNames(todos) {
 
 /**
  * Get the relative path to a group file
- * 
+ *
  * Returns an encoded relative path to a group file relative to a README.md
  * being written to.
- * 
+ *
  * @param {String} readmeFilePath Base file path to compare filePath to
  * @param {String} groupFilePath Group file path
- * 
+ *
  * @requires path
- * 
+ *
  * @returns {String}
  */
 function groupRelativePath(readmeFilePath, groupFilePath) {
@@ -77,7 +77,7 @@ function groupRelativePath(readmeFilePath, groupFilePath) {
  *
  * @requires path
  * @requires notepack-cli/updateTodos.getGroupNames
- * 
+ *
  * @return {String}
  */
 function groupedTodos(todos, filePath, options = {}) {
@@ -97,10 +97,10 @@ ${groupTodos.map(todo => `- [ ] ${todo.todo}`).join('\n')}`;
 
 /**
  * Determines if a folder is valid for processing
- * 
+ *
  * Rejects folders that contain the word "archive" and folders in the
  * project's TEAM_FOLDER.
- * 
+ *
  * @param {String} nodePathName Folder pathname
  * @returns {Boolean}
  */


### PR DESCRIPTION
Updates URL encoding on todo and recent file links in README files to leave `:`, `+`, and `,` characters un-encoded. Leaving these characters encoded was causing errors with some Markdown editors like [Obsidian](https://obsidian.md/).

- Leaves `:`, `+`, and `,` characters un-encoded in generated README links
- Includes updating recent files list in `notepack update` command