### PR TITLE
Create notepack backup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ An Array of alternate names to refer to a team member by. NotePack will automati
 
 ## CLI
 
+### notepack backup
+
+Backup note files by individually committing each new file with a commit message named after the first `H1` in the file or the name of the file (without any YYYY-MM-DD prefix). Also bulk commits updated files with an "Update todos" commit message.
+
+```sh
+> notepack backup
+```
+
+> Pro-tip: set this command up in a cronjob to happen daily after your workday to always make sure your commit history is kept up-to-date
+
 ### notepack configure
 
 Configure NotePack

--- a/bin/notepack
+++ b/bin/notepack
@@ -22,6 +22,10 @@ CONFIG_PATH="$HOME/.notepack_config"
 # Notepack version
 VERSION="$( cat "$DIR/../package.json" | grep -Eo '"version"[^,]*' | sed -n 's/^.*version\": \"\([^\"]*\).*$/\1/p' )"
 
+backup () {
+  node $SCRIPTS_PATH/gitBackup.js
+}
+
 configure () {
   node $SCRIPTS_PATH/configure.js
 }
@@ -167,6 +171,9 @@ watch () {
 }
 
 case "$1" in
+"backup")
+  backup
+  ;;
 "configure")
   configure
   ;;

--- a/src/gitBackup.js
+++ b/src/gitBackup.js
@@ -1,0 +1,153 @@
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+const path = require("path");
+const fs = require('fs');
+
+const { APP_ROOT_FOLDER, BASE_FOLDERS } = require('./userConfig').getUserConfig();
+
+const H1_PATTERN = /^# \w+/gim;
+const FILE_NAME_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2} (.*)$/;
+const STATUS_PATTERN = /^([^\s]+) "?([^"]+)"?$/;
+const STATUS_NEW = 'NEW';
+const STATUS_MODIFIED = 'MODIFIED';
+const STATUSES = {
+  '??': STATUS_NEW,
+  'M': STATUS_MODIFIED
+};
+
+async function asyncForEach(array, callback) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+}
+
+async function commitStaged(message) {
+  const quoteEscapedMessage = message.replace(/(")/g, '\\$1');
+  const { stderr } = await exec(`git -C ${APP_ROOT_FOLDER} commit -m "${quoteEscapedMessage}"`);
+
+  if (stderr) {
+    console.error(stderr);
+    return;
+  }
+
+  console.log('COMMITTED: ' + message);
+
+  return true;
+}
+
+/**
+ * Generate commit message
+ *
+ * Generates a commit message for the file at filePath. Message is generated in
+ * priority order:
+ *   1. The first H1 in the Markdown file
+ *   2. The base name of the file without a date prefix
+ *   3. The base name of the file
+ *
+ * @param {String} filePath Relative path to the file in this repository
+ *
+ * @returns {String}
+ */
+function generateCommitMessage(filePath) {
+  const fileData = fs.readFileSync(path.resolve(APP_ROOT_FOLDER, filePath));
+  const basename = path.basename(filePath, '.md');
+  const h1 = `${fileData}`.match(H1_PATTERN);
+
+  // Markdown title
+  if (h1) {
+    return h1[0];
+  }
+
+  // Title embedded in file name
+  if (FILE_NAME_PATTERN.test(basename)) {
+    return basename.match(FILE_NAME_PATTERN)[1];
+  }
+
+  // Fall back to filename
+  return basename;
+}
+
+async function getStatuses() {
+  let statuses = [];
+  const { stderr, stdout } = await exec(`git -C ${APP_ROOT_FOLDER} status --porcelain`);
+
+  if (stderr) {
+    console.error(stderr);
+    return;
+  }
+
+  stdout.split("\n").forEach(line => {
+    const match = line.trim().match(STATUS_PATTERN);
+
+    if (match) {
+      statuses.push({
+        status: STATUSES[match[1]],
+        filePath: match[2]
+      });
+    }
+  });
+
+  return statuses;
+}
+
+/**
+ * Stage a file
+ *
+ * @param {nodegit<Repository>} repo Instance of nodegit Repository
+ * @param {String} filePath Repo relative path to a file to be staged
+ *
+ * @uses nodegit.Repository.refreshIndex
+ * @uses nodegit.Repository.addByPath
+ * @uses nodegit.Repository.write
+ * @uses nodegit.Repository.writeTree
+ *
+ * @returns {String} oid value for use in a commit
+ */
+async function stageFile(filePath) {
+  const escapeFilePath = filePath.replace(/(\s|&+)/g, '\\$1');
+  const { stderr } = await exec(`git -C ${APP_ROOT_FOLDER} add ${escapeFilePath}`);
+
+  if (stderr) {
+    console.error(stderr);
+    return;
+  }
+
+  console.log('STAGED: ' + filePath);
+
+  return true;
+}
+
+(async () => {
+  const statuses = await getStatuses();
+  // Only process files in the user specified base folders
+  const filtered = statuses.filter((file) => BASE_FOLDERS.some(baseFolder => file.filePath.startsWith(baseFolder)));
+  let updates = [];
+
+  if (!filtered.length) {
+    console.log('Everything has already been backed up 😎');
+    return true;
+  }
+
+  // Individually commit new files
+  await asyncForEach(filtered, async (file) => {
+    const { status, filePath } = file;
+
+    if (status == STATUS_NEW) {
+      const commitMessage = generateCommitMessage(filePath);
+      await stageFile(filePath);
+      await commitStaged(commitMessage);
+    } else {
+      updates.push(file);
+    }
+  });
+
+  // Process updated files (checked off todos)
+  if (updates.length) {
+    await asyncForEach(updates, async (file) => {
+      const { filePath } = file;
+      await stageFile(filePath);
+    });
+
+    await commitStaged('Update todos');
+  }
+})();


### PR DESCRIPTION
Creates the `notepack backup` command which does the following:
- Scans the Note base folders for any new and updated files (does not include files outside configuration specified base folders)
- Commits each new file individually with a commit message based on the first `H1` found in the file's Markdown, or the name of the file (without any `YYYY-MM-DD` prefix)
- Commits all updated files with an "Update todos" message