### PR TITLE
Fix git backup bugs

### DIFF
--- a/src/gitBackup.js
+++ b/src/gitBackup.js
@@ -145,8 +145,7 @@ async function isIgnored(filePath) {
  * @returns {String} oid value for use in a commit
  */
 async function stageFile(filePath) {
-  const escapeFilePath = filePath.replace(/(\s|&+|\(|\))/g, '\\$1');
-  const { stderr } = await exec(`git -C ${APP_ROOT_FOLDER} add ${escapeFilePath}`);
+  const { stderr } = await exec(`git -C ${APP_ROOT_FOLDER} add ${escapedFilePath(filePath)}`);
 
   if (stderr) {
     console.error(stderr);

--- a/src/gitBackup.js
+++ b/src/gitBackup.js
@@ -102,11 +102,13 @@ async function getStatuses() {
     if (match) {
       const status = STATUSES[match[1]];
       const filePath = match[2];
-      const filePathStatus = fs.statSync(path.resolve(APP_ROOT_FOLDER, filePath));
+      const absPath = path.resolve(APP_ROOT_FOLDER, filePath);
+      const filePathStatus = fs.existsSync(absPath) ? fs.statSync(absPath) : false;
+      const isDirectory = filePathStatus ? filePathStatus.isDirectory() : false;
 
       // Folders in the status output indicate completely un-tracked folders
-      if (filePathStatus.isDirectory()) {
-        fs.readdirSync(filePath).forEach((node) => {
+      if (isDirectory) {
+        fs.readdirSync(absPath).forEach((node) => {
           statuses.push({
             status: STATUS_NEW,
             filePath: path.join(filePath, node)

--- a/src/gitBackup.js
+++ b/src/gitBackup.js
@@ -7,6 +7,7 @@ const { APP_ROOT_FOLDER, BASE_FOLDERS } = require('./userConfig').getUserConfig(
 
 const H1_PATTERN = /^# (.+)$/im;
 const FILE_NAME_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2} (.*)$/;
+const TEXT_EXTENSIONS_PATTERN = /md|txt$/;
 const STATUS_PATTERN = /^(.{2}) "?([^"]+)"?$/;
 const STATUS_NEW = 'NEW';
 const STATUS_MODIFIED = 'MODIFIED';
@@ -51,13 +52,18 @@ async function commitStaged(message) {
  * @returns {String}
  */
 function generateCommitMessage(filePath) {
-  const fileData = fs.readFileSync(path.resolve(APP_ROOT_FOLDER, filePath));
+  const extName = path.extname(filePath);
   const basename = path.basename(filePath, '.md');
-  const h1 = `${fileData}`.match(H1_PATTERN);
 
-  // Markdown title
-  if (h1) {
-    return h1[1];
+  // Only process text files for headings
+  if (TEXT_EXTENSIONS_PATTERN.test(extName)) {
+    const fileData = fs.readFileSync(path.resolve(APP_ROOT_FOLDER, filePath));
+    const h1 = `${fileData}`.match(H1_PATTERN);
+
+    // Markdown title
+    if (h1) {
+      return h1[1];
+    }
   }
 
   // Title embedded in file name

--- a/src/gitBackup.js
+++ b/src/gitBackup.js
@@ -11,11 +11,13 @@ const TEXT_EXTENSIONS_PATTERN = /md|txt$/;
 const STATUS_PATTERN = /^(.{2}) "?([^"]+)"?$/;
 const STATUS_NEW = 'NEW';
 const STATUS_MODIFIED = 'MODIFIED';
-const STATUS_MODIFIED_STAGED = 'MODIFIED STAGED'
+const STATUS_MODIFIED_STAGED = 'MODIFIED STAGED';
+const STATUS_DELETED = 'DELETED';
 const STATUSES = {
   '??': STATUS_NEW,
   ' M': STATUS_MODIFIED,
-  'M ': STATUS_MODIFIED_STAGED
+  'M ': STATUS_MODIFIED_STAGED,
+  ' D': STATUS_DELETED
 };
 
 async function asyncForEach(array, callback) {


### PR DESCRIPTION
Fixes bugs with the `notepack backup` command:
- Handle file deletions
- Handle new un-tracked folders containing un-tracked files
- Handle ignored files
- Skip scanning file contents if file is not a text file